### PR TITLE
Add errors in F304 & F305 in case of missing CGM output

### DIFF
--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/PostProcessingService.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/PostProcessingService.java
@@ -121,20 +121,13 @@ public class PostProcessingService {
                         .filter(processFileDto -> processFileDto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED))
                         .forEach(processFileDto -> {
                             switch (processFileDto.getFileType()) {
-                                case "CNE":
-                                    cnes.put(taskDto, processFileDto);
-                                    break;
-                                case "CGM_OUT":
-                                    cgms.put(taskDto, processFileDto);
-                                    break;
-                                case "METADATA":
-                                    metadatas.put(taskDto, processFileDto);
-                                    break;
-                                case "RAO_RESULT":
-                                    raoResults.put(taskDto, processFileDto);
-                                    break;
-                                default:
+                                case "CNE"-> cnes.put(taskDto, processFileDto);
+                                case "CGM_OUT" -> cgms.put(taskDto, processFileDto);
+                                case "METADATA" -> metadatas.put(taskDto, processFileDto);
+                                case "RAO_RESULT" -> raoResults.put(taskDto, processFileDto);
+                                default -> {
                                     // do nothing, other outputs are available but we won't be collecting them
+                                }
                             }
                         })
         );

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/PostProcessingService.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/PostProcessingService.java
@@ -121,7 +121,7 @@ public class PostProcessingService {
                         .filter(processFileDto -> processFileDto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED))
                         .forEach(processFileDto -> {
                             switch (processFileDto.getFileType()) {
-                                case "CNE"-> cnes.put(taskDto, processFileDto);
+                                case "CNE" -> cnes.put(taskDto, processFileDto);
                                 case "CGM_OUT" -> cgms.put(taskDto, processFileDto);
                                 case "METADATA" -> metadatas.put(taskDto, processFileDto);
                                 case "RAO_RESULT" -> raoResults.put(taskDto, processFileDto);

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/ZipAndUploadService.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/ZipAndUploadService.java
@@ -13,7 +13,6 @@ import com.farao_community.farao.core_cc_post_processing.app.util.NamingRules;
 import com.farao_community.farao.core_cc_post_processing.app.util.RaoMetadata;
 import com.farao_community.farao.core_cc_post_processing.app.util.ZipUtil;
 import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileDto;
-import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileStatus;
 import com.farao_community.farao.gridcapa.task_manager.api.TaskDto;
 import com.farao_community.farao.gridcapa_core_cc.api.exception.CoreCCInternalException;
 import com.farao_community.farao.minio_adapter.starter.MinioAdapter;
@@ -87,8 +86,6 @@ public class ZipAndUploadService {
 
         // Add all cgms from minio to tmp folder
         cgms.values()
-                .stream()
-                .filter(processFileDto -> processFileDto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED))
                 .forEach(cgm -> {
                     final InputStream inputStream = minioAdapter.getFileFromFullPath(cgm.getFilePath());
                     final File cgmFile = new File(cgmZipTmpDir + cgm.getFilename());
@@ -126,8 +123,7 @@ public class ZipAndUploadService {
         final String cneZipTmpDir = TMP + "cnes_out/" + localDate.toString() + "/";
 
         // Add all cnes from minio to tmp folder
-        cnes.values().stream()
-                .filter(processFileDto -> processFileDto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED))
+        cnes.values()
                 .forEach(cne -> {
                     final InputStream inputStream = minioAdapter.getFileFromFullPath(cne.getFilePath());
                     final File cneFile = new File(cneZipTmpDir + cne.getFilename());
@@ -156,8 +152,6 @@ public class ZipAndUploadService {
 
         // Add all raoResult json files from minio to tmp folder
         raoResults.values()
-                .stream()
-                .filter(processFileDto -> processFileDto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED))
                 .forEach(raoResult -> {
                     try (final InputStream inputStream = minioAdapter.getFileFromFullPath(raoResult.getFilePath())) {
                         final File raoResultFile = new File(raoResultZipTmpDir + raoResult.getFilename());

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/Utils.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/Utils.java
@@ -46,11 +46,13 @@ public class Utils {
     public static final ProcessFileDto RAO_RESULT_FILE_DTO_NOT_PRESENT = new ProcessFileDto("/CORE/CC/raoResult.json", "RAO_RESULT", ProcessFileStatus.NOT_PRESENT, "raoResult.json", "docId", TIMESTAMP);
     public static final List<ProcessFileDto> INPUTS = List.of(CRAC_PROCESS_FILE);
     public static final List<ProcessFileDto> OUTPUTS = List.of(CNE_FILE_DTO, CGM_FILE_DTO, METADATA_FILE_DTO, RAO_RESULT_FILE_DTO);
+    public static final List<ProcessFileDto> OUTPUTS_CGM_NOT_PRESENT = List.of(CNE_FILE_DTO, CGM_FILE_DTO_NOT_PRESENT, METADATA_FILE_DTO, RAO_RESULT_FILE_DTO);
     public static final List<ProcessFileDto> OUTPUTS_NOT_PRESENT = List.of(CNE_FILE_DTO_NOT_PRESENT, CGM_FILE_DTO_NOT_PRESENT, METADATA_FILE_DTO, RAO_RESULT_FILE_DTO_NOT_PRESENT);
     public static final List<ProcessEventDto> PROCESS_EVENTS = List.of();
     public static final List<ProcessRunDto> PROCESS_RUN_DTOS_ONE = List.of(new ProcessRunDto(UUID.randomUUID(), OffsetDateTime.parse("2023-08-21T15:16:45Z"), INPUTS));
     public static final List<ProcessRunDto> PROCESS_RUN_DTOS_TWO = List.of(new ProcessRunDto(UUID.randomUUID(), OffsetDateTime.parse("2023-08-21T15:16:45Z"), INPUTS), new ProcessRunDto(UUID.randomUUID(), OffsetDateTime.parse("2023-08-22T15:16:45Z"), INPUTS));
     public static final TaskDto SUCCESS_TASK = new TaskDto(UUID.fromString("4fb56583-bcec-4ed9-9839-0984b7324989"), OffsetDateTime.parse("2023-08-21T15:16:45Z"), TaskStatus.SUCCESS, INPUTS, INPUTS, OUTPUTS, PROCESS_EVENTS, PROCESS_RUN_DTOS_ONE, List.of());
+    public static final TaskDto SUCCESS_TASK_CGM_NOT_PRESENT = new TaskDto(UUID.fromString("4fb56583-bcec-4ed9-9839-0984b7324989"), OffsetDateTime.parse("2023-08-21T15:16:45Z"), TaskStatus.SUCCESS, INPUTS, INPUTS, OUTPUTS_CGM_NOT_PRESENT, PROCESS_EVENTS, PROCESS_RUN_DTOS_ONE, List.of());
     public static final TaskDto SUCCESS_TASK_NOT_PRESENT_STATUS = new TaskDto(UUID.fromString("4fb56583-bcec-4ed9-9839-0984b7324989"), OffsetDateTime.parse("2023-08-21T15:16:45Z"), TaskStatus.SUCCESS, INPUTS, INPUTS, OUTPUTS_NOT_PRESENT, PROCESS_EVENTS, PROCESS_RUN_DTOS_ONE, List.of());
     public static final TaskDto ERROR_TASK = new TaskDto(UUID.fromString("6e3e0ef2-96e4-4649-82d4-374f103038d4"), OffsetDateTime.parse("2023-08-21T15:16:46Z"), TaskStatus.ERROR, INPUTS, INPUTS, OUTPUTS, PROCESS_EVENTS, PROCESS_RUN_DTOS_ONE, List.of());
     public static final TaskDto ERROR_TASK_NO_METADATA = new TaskDto(UUID.fromString("6e3e0ef2-96e4-4649-82d4-374f103038d9"), OffsetDateTime.parse("2023-08-21T15:16:48Z"), TaskStatus.ERROR, INPUTS, INPUTS, OUTPUTS, PROCESS_EVENTS, PROCESS_RUN_DTOS_ONE, List.of());

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/ZipAndUploadServiceTest.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/ZipAndUploadServiceTest.java
@@ -36,19 +36,15 @@ import java.util.List;
 import java.util.Map;
 
 import static com.farao_community.farao.core_cc_post_processing.app.Utils.CGM_FILE_DTO;
-import static com.farao_community.farao.core_cc_post_processing.app.Utils.CGM_FILE_DTO_NOT_PRESENT;
 import static com.farao_community.farao.core_cc_post_processing.app.Utils.CNE_FILE_DTO;
 import static com.farao_community.farao.core_cc_post_processing.app.Utils.RAO_RESULT_FILE_DTO;
-import static com.farao_community.farao.core_cc_post_processing.app.Utils.RAO_RESULT_FILE_DTO_NOT_PRESENT;
 import static com.farao_community.farao.core_cc_post_processing.app.Utils.SUCCESS_TASK;
-import static com.farao_community.farao.core_cc_post_processing.app.Utils.SUCCESS_TASK_NOT_PRESENT_STATUS;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -104,22 +100,6 @@ class ZipAndUploadServiceTest {
         assertFalse(new File("/tmp/cgms_out/2023-08-04").exists());
     }
 
-    @Test
-    void testZipCgmsNotPresentAndSendToOutputs() {
-        final Map<TaskDto, ProcessFileDto> cgms = new HashMap<>();
-        cgms.put(SUCCESS_TASK_NOT_PRESENT_STATUS, CGM_FILE_DTO_NOT_PRESENT);
-
-        zipAndUploadService.zipCgmsAndSendToOutputs(TARGET_FOLDER,
-                cgms,
-                LOCAL_DATE,
-                "00000000-0000-0000-0000-000000000000",
-                "2019-01-07T23:00Z/2019-01-08T23:00Z",
-                1);
-        //In case of NOT ProcessFileStatus == VALIDATED, should not retrieve cgm from minio
-        verify(minioAdapterMock, never()).getFileFromFullPath(anyString());
-        verify(minioAdapterMock).uploadOutput(anyString(), any(InputStream.class));
-    }
-
     // ------------ CNES ------------
     @Test
     void testZipCnesAndSendToOutputs() {
@@ -135,19 +115,6 @@ class ZipAndUploadServiceTest {
         verify(minioAdapterMock).uploadOutput(anyString(), any(InputStream.class));
 
         assertFalse(new File("/tmp/cnes_out/2023-08-04").exists());
-    }
-
-    @Test
-    void testZipCnesNotPresentAndSendToOutputs() {
-        final Map<TaskDto, ProcessFileDto> cnes = new HashMap<>();
-        cnes.put(SUCCESS_TASK_NOT_PRESENT_STATUS, CGM_FILE_DTO_NOT_PRESENT);
-        zipAndUploadService.zipCnesAndSendToOutputs(TARGET_FOLDER,
-                cnes,
-                LOCAL_DATE,
-                1);
-        //In case of NOT ProcessFileStatus == VALIDATED, should not retrieve cgm from minio
-        verify(minioAdapterMock, never()).getFileFromFullPath(anyString());
-        verify(minioAdapterMock).uploadOutput(anyString(), any(InputStream.class));
     }
 
     // ------------ RAO_RESULT ------------
@@ -166,17 +133,6 @@ class ZipAndUploadServiceTest {
         assertFalse(new File("/tmp/raoResults_out/2023-08-04").exists());
     }
 
-    @Test
-    void testZipRaoResultNotPresentAndSendToOutputs() {
-        final Map<TaskDto, ProcessFileDto> cnes = new HashMap<>();
-        cnes.put(SUCCESS_TASK_NOT_PRESENT_STATUS, RAO_RESULT_FILE_DTO_NOT_PRESENT);
-        zipAndUploadService.zipRaoResultsAndSendToOutputs(TARGET_FOLDER,
-                cnes,
-                LOCAL_DATE);
-        //In case of NOT ProcessFileStatus == VALIDATED, should not retrieve cgm from minio
-        verify(minioAdapterMock, never()).getFileFromFullPath(anyString());
-        verify(minioAdapterMock).uploadOutput(anyString(), any(InputStream.class));
-    }
     // ------------ UPLOAD ------------
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced task processing includes additional parameters for generating responses, improving the handling of task data.
	- Introduced new scenarios to account for tasks with missing outputs, ensuring better representation of processing states.
- **Bug Fixes**
	- Removed unnecessary validation checks in file zipping processes, simplifying the logic for handling outputs.
- **Refactor**
	- Streamlined processing logic and improved error handling for task statuses, leading to more robust responses.
- **Tests**
	- Added new tests to validate behavior when tasks lack outputs, while simplifying existing tests for metadata fetching.
	- Removed outdated tests related to non-present files in the zipping process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->