### PR TITLE
Refactor for reusing daily F303 generator

### DIFF
--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/PostProcessingService.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/PostProcessingService.java
@@ -7,10 +7,7 @@
 package com.farao_community.farao.core_cc_post_processing.app;
 
 import com.farao_community.farao.core_cc_post_processing.app.exception.CoreCCPostProcessingInternalException;
-import com.farao_community.farao.core_cc_post_processing.app.services.CoreCCMetadataGenerator;
-import com.farao_community.farao.core_cc_post_processing.app.services.DailyF303Generator;
-import com.farao_community.farao.core_cc_post_processing.app.services.F305XmlGenerator;
-import com.farao_community.farao.core_cc_post_processing.app.services.ZipAndUploadService;
+import com.farao_community.farao.core_cc_post_processing.app.services.*;
 import com.farao_community.farao.core_cc_post_processing.app.util.NamingRules;
 import com.farao_community.farao.core_cc_post_processing.app.util.RaoMetadata;
 import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileDto;
@@ -96,7 +93,7 @@ public class PostProcessingService {
         // -- F299 : cnes
         zipAndUploadService.zipCnesAndSendToOutputs(outputsTargetMinioFolder, cnePerTask, localDate, outputFileVersion);
         // -- F303 : flowBasedConstraintDocument
-        zipAndUploadService.uploadF303ToMinio(new DailyF303Generator(minioAdapter).generate(tasksToPostProcess), outputsTargetMinioFolder, localDate, outputFileVersion);
+        zipAndUploadService.uploadF303ToMinio(DailyF303Generator.generate(new TaskDtoBasedDailyF303InputsProvider(tasksToPostProcess, minioAdapter)), outputsTargetMinioFolder, localDate, outputFileVersion);
         // -- F305 : RaoResponse
         zipAndUploadService.uploadF305ToMinio(outputsTargetMinioFolder, F305XmlGenerator.generateRaoResponse(tasksToPostProcess, cgmPerTask, localDate, raoMetadata.getCorrelationId(), metadataMap, raoMetadata.getTimeInterval()), localDate, outputFileVersion);
         LOGGER.info("All outputs were uploaded");

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/PostProcessingService.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/PostProcessingService.java
@@ -96,7 +96,7 @@ public class PostProcessingService {
         // -- F299 : cnes
         zipAndUploadService.zipCnesAndSendToOutputs(outputsTargetMinioFolder, cnePerTask, localDate, outputFileVersion);
         // -- F303 : flowBasedConstraintDocument
-        zipAndUploadService.uploadF303ToMinio(new DailyF303Generator(minioAdapter).generate(raoResultPerTask, cgmPerTask), outputsTargetMinioFolder, localDate, outputFileVersion);
+        zipAndUploadService.uploadF303ToMinio(new DailyF303Generator(minioAdapter).generate(tasksToPostProcess), outputsTargetMinioFolder, localDate, outputFileVersion);
         // -- F305 : RaoResponse
         zipAndUploadService.uploadF305ToMinio(outputsTargetMinioFolder, F305XmlGenerator.generateRaoResponse(tasksToPostProcess, cgmPerTask, localDate, raoMetadata.getCorrelationId(), metadataMap, raoMetadata.getTimeInterval()), localDate, outputFileVersion);
         LOGGER.info("All outputs were uploaded");

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Clusterizer.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Clusterizer.java
@@ -257,7 +257,7 @@ class DailyF303Clusterizer {
     }
 
     private static boolean areMnecEqual(CriticalBranchType cb1, CriticalBranchType cb2) {
-        return cb1.isMNEC() && cb2.isMNEC() || !cb1.isMNEC() && !cb2.isMNEC();
+        return cb1.isMNEC() == null && cb2.isMNEC() == null || cb1.isMNEC() && cb2.isMNEC() || !cb1.isMNEC() && !cb2.isMNEC();
     }
 
     private static boolean areOriginEqual(CriticalBranchType cb1, CriticalBranchType cb2) {

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
@@ -9,18 +9,22 @@ package com.farao_community.farao.core_cc_post_processing.app.services;
 import com.farao_community.farao.core_cc_post_processing.app.exception.CoreCCPostProcessingInternalException;
 import com.farao_community.farao.core_cc_post_processing.app.util.IntervalUtil;
 import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileDto;
+import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileStatus;
 import com.farao_community.farao.gridcapa.task_manager.api.TaskDto;
 import com.farao_community.farao.gridcapa.task_manager.api.TaskStatus;
 import com.farao_community.farao.minio_adapter.starter.MinioAdapter;
+import com.powsybl.iidm.network.Network;
 import com.powsybl.openrao.data.crac.api.parameters.CracCreationParameters;
 import com.powsybl.openrao.data.crac.api.parameters.JsonCracCreationParameters;
+import com.powsybl.openrao.data.crac.io.fbconstraint.FbConstraintCreationContext;
+import com.powsybl.openrao.data.crac.io.fbconstraint.FbConstraintImporter;
 import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.FlowBasedConstraintDocument;
+import com.powsybl.openrao.data.raoresult.api.RaoResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.threeten.extra.Interval;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -29,7 +33,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.farao_community.farao.core_cc_post_processing.app.util.CracUtil.getBytesFromInputStream;
 import static com.farao_community.farao.core_cc_post_processing.app.util.CracUtil.importNativeCrac;
 
 /**
@@ -58,36 +61,37 @@ public class DailyF303Generator {
             .findFirst().orElseThrow(() -> new CoreCCPostProcessingInternalException("task dto missing cbcora file"))
             .getFilePath();
         CracCreationParameters cracCreationParameters = getCimCracCreationParameters();
+        FlowBasedConstraintDocument flowBasedConstraintDocument;
         try (final InputStream cracXmlInputStream = minioAdapter.getFileFromFullPath(cracFilePath)) {
-            final byte[] cracXmlBytes = getBytesFromInputStream(cracXmlInputStream);
-            final FlowBasedConstraintDocument flowBasedConstraintDocument;
-            try (final InputStream firstUseStream = new ByteArrayInputStream(cracXmlBytes)) {
-                flowBasedConstraintDocument = importNativeCrac(firstUseStream);
-            }
-            // generate F303Info for each hour of the initial CRAC
-            Map<Integer, Interval> positionMap = IntervalUtil.getPositionsMap(flowBasedConstraintDocument.getConstraintTimeInterval().getV());
-            List<HourlyF303Info> hourlyF303Infos = new ArrayList<>();
-            positionMap.values().forEach(interval -> {
-                Optional<TaskDto> taskDtoOptional =  getTaskDtoOfInterval(interval, tasks);
-                if (taskDtoOptional.isPresent()) {
-                    TaskDto taskDto = taskDtoOptional.get();
-                    if (taskDto.getStatus().equals(TaskStatus.SUCCESS)) {
-                        hourlyF303Infos.add(new HourlyF303InfoGenerator(flowBasedConstraintDocument, interval, taskDto, minioAdapter, cracCreationParameters)
-                                .generate());
-                    } else {
-                        hourlyF303Infos.add(new HourlyF303InfoGenerator(flowBasedConstraintDocument, interval, taskDto, minioAdapter, cracCreationParameters)
-                                .generateForError());
-                    }
-                } else {
-                    LOGGER.warn(String.format("Cannot find taskDto for interval %s", interval));
-                }
-            });
-
-            // gather hourly info in one common document, cluster the elements that can be clusterized
-            return new DailyF303Clusterizer(hourlyF303Infos, flowBasedConstraintDocument).generateClusterizedDocument();
+            flowBasedConstraintDocument = importNativeCrac(cracXmlInputStream);
         } catch (Exception e) {
             throw new CoreCCPostProcessingInternalException("Exception occurred during F303 file creation", e);
         }
+        Map<Integer, Interval> positionMap = IntervalUtil.getPositionsMap(flowBasedConstraintDocument.getConstraintTimeInterval().getV());
+        List<HourlyF303Info> hourlyF303Infos = new ArrayList<>();
+        positionMap.values().forEach(interval -> {
+            Optional<TaskDto> taskDtoOptional =  getTaskDtoOfInterval(interval, tasks);
+            if (taskDtoOptional.isPresent()) {
+                TaskDto taskDto = taskDtoOptional.get();
+                try {
+                    Network network = getNetworkOfTaskDto(taskDto, minioAdapter);
+                    FbConstraintCreationContext crac = getCracOfTaskDto(network, taskDto, minioAdapter, cracCreationParameters);
+                    RaoResult raoResult = getRaoResultOfTaskDto(crac, taskDto, minioAdapter);
+                    if (taskDto.getStatus().equals(TaskStatus.SUCCESS)) {
+                        hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForSuccessfulInterval(flowBasedConstraintDocument, interval, taskDto.getTimestamp(), crac, raoResult));
+                    } else {
+                        hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForNonRequestedOrFailedInterval(flowBasedConstraintDocument, interval));
+                    }
+                } catch (Exception e) {
+                    hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForNonRequestedOrFailedInterval(flowBasedConstraintDocument, interval));
+                }
+            } else {
+                hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForNonRequestedOrFailedInterval(flowBasedConstraintDocument, interval));
+            }
+        });
+
+        // gather hourly info in one common document, cluster the elements that can be clusterized
+        return new DailyF303Clusterizer(hourlyF303Infos, flowBasedConstraintDocument).generateClusterizedDocument();
     }
 
     private Optional<TaskDto> getTaskDtoOfInterval(Interval interval, Set<TaskDto> taskDtos) {
@@ -97,5 +101,53 @@ public class DailyF303Generator {
     private CracCreationParameters getCimCracCreationParameters() {
         LOGGER.info("Importing Crac Creation Parameters file: {}", CRAC_CREATION_PARAMETERS_JSON);
         return JsonCracCreationParameters.read(getClass().getResourceAsStream(CRAC_CREATION_PARAMETERS_JSON));
+    }
+
+    private Network getNetworkOfTaskDto(TaskDto taskDto, MinioAdapter minioAdapter) {
+        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
+                .stream()
+                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
+                        dto.getFileType().equals("CGM_OUT"))
+                .findAny();
+        if (processFileDto.isEmpty()) {
+            throw new RuntimeException("Missing file");
+        }
+        try (InputStream networkInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
+            return Network.read(processFileDto.get().getFilename(), networkInputStream);
+        } catch (IOException e) {
+            throw new CoreCCPostProcessingInternalException(String.format("Cannot import network of task %s", taskDto.getTimestamp()), e);
+        }
+    }
+
+    private FbConstraintCreationContext getCracOfTaskDto(Network network, TaskDto taskDto, MinioAdapter minioAdapter, CracCreationParameters cracCreationParameters) {
+        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
+                .stream()
+                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
+                        dto.getFileType().equals("CBCORA"))
+                .findAny();
+        if (processFileDto.isEmpty()) {
+            throw new RuntimeException("Missing file");
+        }
+        try (InputStream cracInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
+            return (FbConstraintCreationContext) new FbConstraintImporter().importData(cracInputStream, cracCreationParameters, network, taskDto.getTimestamp());
+        } catch (IOException e) {
+            throw new CoreCCPostProcessingInternalException(String.format("Cannot import network of task %s", taskDto.getTimestamp()), e);
+        }
+    }
+
+    private RaoResult getRaoResultOfTaskDto(FbConstraintCreationContext crac, TaskDto taskDto, MinioAdapter minioAdapter) {
+        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
+                .stream()
+                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
+                        dto.getFileType().equals("RAO_RESULT"))
+                .findAny();
+        if (processFileDto.isEmpty()) {
+            throw new RuntimeException("Missing file");
+        }
+        try (InputStream raoResultInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
+            return RaoResult.read(raoResultInputStream, crac.getCrac());
+        } catch (IOException e) {
+            throw new CoreCCPostProcessingInternalException(String.format("Cannot import RAO result of hourly RAO response of instant %s", taskDto.getTimestamp()), e);
+        }
     }
 }

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
@@ -27,17 +27,18 @@ public class DailyF303Generator {
     private DailyF303Generator() {
         throw new AssertionError("Static class. Should not be constructed");}
 
-
     public static FlowBasedConstraintDocument generate(DailyF303GeneratorInputsProvider inputsProvider) {
         FlowBasedConstraintDocument flowBasedConstraintDocument = inputsProvider.referenceConstraintDocument();
         Map<Integer, Interval> positionMap = IntervalUtil.getPositionsMap(flowBasedConstraintDocument.getConstraintTimeInterval().getV());
         List<HourlyF303Info> hourlyF303Infos = new ArrayList<>();
         positionMap.values().forEach(interval -> {
-            Optional<HourlyF303InfoGenerator.Inputs> optionalInputs = inputsProvider.hourlyF303InputsForInterval(interval);
-            if (optionalInputs.isPresent()) {
-                hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForSuccessfulInterval(flowBasedConstraintDocument, interval, optionalInputs.get()));
-            } else {
-                hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForNonRequestedOrFailedInterval(flowBasedConstraintDocument, interval));
+            if (inputsProvider.shouldBeReported(interval)) {
+                Optional<HourlyF303InfoGenerator.Inputs> optionalInputs = inputsProvider.hourlyF303InputsForInterval(interval);
+                if (optionalInputs.isPresent()) {
+                    hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForSuccessfulInterval(flowBasedConstraintDocument, interval, optionalInputs.get()));
+                } else {
+                    hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForNonRequestedOrFailedInterval(flowBasedConstraintDocument, interval));
+                }
             }
         });
 

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
@@ -22,10 +22,11 @@ import java.util.Optional;
  * @author Philippe Edwards {@literal <philippe.edwards at rte-france.com>}
  * @author Godelaine de Montmorillon {@literal <godelaine.demontmorillon at rte-france.com>}
  */
-public class DailyF303Generator {
+public final class DailyF303Generator {
 
     private DailyF303Generator() {
-        throw new AssertionError("Static class. Should not be constructed");}
+        throw new AssertionError("Static class. Should not be constructed");
+    }
 
     public static FlowBasedConstraintDocument generate(DailyF303GeneratorInputsProvider inputsProvider) {
         FlowBasedConstraintDocument flowBasedConstraintDocument = inputsProvider.referenceConstraintDocument();

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
@@ -6,34 +6,14 @@
  */
 package com.farao_community.farao.core_cc_post_processing.app.services;
 
-import com.farao_community.farao.core_cc_post_processing.app.exception.CoreCCPostProcessingInternalException;
 import com.farao_community.farao.core_cc_post_processing.app.util.IntervalUtil;
-import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileDto;
-import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileStatus;
-import com.farao_community.farao.gridcapa.task_manager.api.TaskDto;
-import com.farao_community.farao.gridcapa.task_manager.api.TaskStatus;
-import com.farao_community.farao.minio_adapter.starter.MinioAdapter;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.openrao.data.crac.api.parameters.CracCreationParameters;
-import com.powsybl.openrao.data.crac.api.parameters.JsonCracCreationParameters;
-import com.powsybl.openrao.data.crac.io.fbconstraint.FbConstraintCreationContext;
-import com.powsybl.openrao.data.crac.io.fbconstraint.FbConstraintImporter;
 import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.FlowBasedConstraintDocument;
-import com.powsybl.openrao.data.raoresult.api.RaoResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 import org.threeten.extra.Interval;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-
-import static com.farao_community.farao.core_cc_post_processing.app.util.CracUtil.importNativeCrac;
 
 /**
  * @author Pengbo Wang {@literal <pengbo.wang at rte-international.com>}
@@ -42,49 +22,20 @@ import static com.farao_community.farao.core_cc_post_processing.app.util.CracUti
  * @author Philippe Edwards {@literal <philippe.edwards at rte-france.com>}
  * @author Godelaine de Montmorillon {@literal <godelaine.demontmorillon at rte-france.com>}
  */
-@Service
 public class DailyF303Generator {
 
-    public static final String CRAC_CREATION_PARAMETERS_JSON = "/crac/cracCreationParameters.json";
-    private static final Logger LOGGER = LoggerFactory.getLogger(DailyF303Generator.class);
-    private final MinioAdapter minioAdapter;
+    private DailyF303Generator() {
+        throw new AssertionError("Static class. Should not be constructed");}
 
-    public DailyF303Generator(MinioAdapter minioAdapter) {
-        this.minioAdapter = minioAdapter;
-    }
 
-    public FlowBasedConstraintDocument generate(Set<TaskDto> tasks) {
-        String cracFilePath = tasks.stream()
-            .findFirst().orElseThrow()
-            .getInputs()
-            .stream().filter(processFileDto -> processFileDto.getFileType().equals("CBCORA"))
-            .findFirst().orElseThrow(() -> new CoreCCPostProcessingInternalException("task dto missing cbcora file"))
-            .getFilePath();
-        CracCreationParameters cracCreationParameters = getCimCracCreationParameters();
-        FlowBasedConstraintDocument flowBasedConstraintDocument;
-        try (final InputStream cracXmlInputStream = minioAdapter.getFileFromFullPath(cracFilePath)) {
-            flowBasedConstraintDocument = importNativeCrac(cracXmlInputStream);
-        } catch (Exception e) {
-            throw new CoreCCPostProcessingInternalException("Exception occurred during F303 file creation", e);
-        }
+    public static FlowBasedConstraintDocument generate(DailyF303GeneratorInputsProvider inputsProvider) {
+        FlowBasedConstraintDocument flowBasedConstraintDocument = inputsProvider.referenceConstraintDocument();
         Map<Integer, Interval> positionMap = IntervalUtil.getPositionsMap(flowBasedConstraintDocument.getConstraintTimeInterval().getV());
         List<HourlyF303Info> hourlyF303Infos = new ArrayList<>();
         positionMap.values().forEach(interval -> {
-            Optional<TaskDto> taskDtoOptional =  getTaskDtoOfInterval(interval, tasks);
-            if (taskDtoOptional.isPresent()) {
-                TaskDto taskDto = taskDtoOptional.get();
-                try {
-                    Network network = getNetworkOfTaskDto(taskDto, minioAdapter);
-                    FbConstraintCreationContext crac = getCracOfTaskDto(network, taskDto, minioAdapter, cracCreationParameters);
-                    RaoResult raoResult = getRaoResultOfTaskDto(crac, taskDto, minioAdapter);
-                    if (taskDto.getStatus().equals(TaskStatus.SUCCESS)) {
-                        hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForSuccessfulInterval(flowBasedConstraintDocument, interval, taskDto.getTimestamp(), crac, raoResult));
-                    } else {
-                        hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForNonRequestedOrFailedInterval(flowBasedConstraintDocument, interval));
-                    }
-                } catch (Exception e) {
-                    hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForNonRequestedOrFailedInterval(flowBasedConstraintDocument, interval));
-                }
+            Optional<HourlyF303InfoGenerator.Inputs> optionalInputs = inputsProvider.hourlyF303InputsForInterval(interval);
+            if (optionalInputs.isPresent()) {
+                hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForSuccessfulInterval(flowBasedConstraintDocument, interval, optionalInputs.get()));
             } else {
                 hourlyF303Infos.add(HourlyF303InfoGenerator.getInfoForNonRequestedOrFailedInterval(flowBasedConstraintDocument, interval));
             }
@@ -92,62 +43,5 @@ public class DailyF303Generator {
 
         // gather hourly info in one common document, cluster the elements that can be clusterized
         return new DailyF303Clusterizer(hourlyF303Infos, flowBasedConstraintDocument).generateClusterizedDocument();
-    }
-
-    private Optional<TaskDto> getTaskDtoOfInterval(Interval interval, Set<TaskDto> taskDtos) {
-        return taskDtos.stream().filter(taskDto -> interval.contains(taskDto.getTimestamp().toInstant())).findFirst();
-    }
-
-    private CracCreationParameters getCimCracCreationParameters() {
-        LOGGER.info("Importing Crac Creation Parameters file: {}", CRAC_CREATION_PARAMETERS_JSON);
-        return JsonCracCreationParameters.read(getClass().getResourceAsStream(CRAC_CREATION_PARAMETERS_JSON));
-    }
-
-    private Network getNetworkOfTaskDto(TaskDto taskDto, MinioAdapter minioAdapter) {
-        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
-                .stream()
-                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
-                        dto.getFileType().equals("CGM_OUT"))
-                .findAny();
-        if (processFileDto.isEmpty()) {
-            throw new RuntimeException("Missing file");
-        }
-        try (InputStream networkInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
-            return Network.read(processFileDto.get().getFilename(), networkInputStream);
-        } catch (IOException e) {
-            throw new CoreCCPostProcessingInternalException(String.format("Cannot import network of task %s", taskDto.getTimestamp()), e);
-        }
-    }
-
-    private FbConstraintCreationContext getCracOfTaskDto(Network network, TaskDto taskDto, MinioAdapter minioAdapter, CracCreationParameters cracCreationParameters) {
-        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
-                .stream()
-                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
-                        dto.getFileType().equals("CBCORA"))
-                .findAny();
-        if (processFileDto.isEmpty()) {
-            throw new RuntimeException("Missing file");
-        }
-        try (InputStream cracInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
-            return (FbConstraintCreationContext) new FbConstraintImporter().importData(cracInputStream, cracCreationParameters, network, taskDto.getTimestamp());
-        } catch (IOException e) {
-            throw new CoreCCPostProcessingInternalException(String.format("Cannot import network of task %s", taskDto.getTimestamp()), e);
-        }
-    }
-
-    private RaoResult getRaoResultOfTaskDto(FbConstraintCreationContext crac, TaskDto taskDto, MinioAdapter minioAdapter) {
-        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
-                .stream()
-                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
-                        dto.getFileType().equals("RAO_RESULT"))
-                .findAny();
-        if (processFileDto.isEmpty()) {
-            throw new RuntimeException("Missing file");
-        }
-        try (InputStream raoResultInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
-            return RaoResult.read(raoResultInputStream, crac.getCrac());
-        } catch (IOException e) {
-            throw new CoreCCPostProcessingInternalException(String.format("Cannot import RAO result of hourly RAO response of instant %s", taskDto.getTimestamp()), e);
-        }
     }
 }

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator.java
@@ -21,6 +21,7 @@ import java.util.Optional;
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com}
  * @author Philippe Edwards {@literal <philippe.edwards at rte-france.com>}
  * @author Godelaine de Montmorillon {@literal <godelaine.demontmorillon at rte-france.com>}
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  */
 public final class DailyF303Generator {
 

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303GeneratorInputsProvider.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303GeneratorInputsProvider.java
@@ -1,0 +1,12 @@
+package com.farao_community.farao.core_cc_post_processing.app.services;
+
+import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.FlowBasedConstraintDocument;
+import org.threeten.extra.Interval;
+
+import java.util.Optional;
+
+public interface DailyF303GeneratorInputsProvider {
+    FlowBasedConstraintDocument referenceConstraintDocument();
+
+    Optional<HourlyF303InfoGenerator.Inputs> hourlyF303InputsForInterval(Interval interval);
+}

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303GeneratorInputsProvider.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303GeneratorInputsProvider.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.farao_community.farao.core_cc_post_processing.app.services;
 
 import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.FlowBasedConstraintDocument;
@@ -5,6 +11,9 @@ import org.threeten.extra.Interval;
 
 import java.util.Optional;
 
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
 public interface DailyF303GeneratorInputsProvider {
     FlowBasedConstraintDocument referenceConstraintDocument();
 

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303GeneratorInputsProvider.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303GeneratorInputsProvider.java
@@ -9,4 +9,7 @@ public interface DailyF303GeneratorInputsProvider {
     FlowBasedConstraintDocument referenceConstraintDocument();
 
     Optional<HourlyF303InfoGenerator.Inputs> hourlyF303InputsForInterval(Interval interval);
+
+    boolean shouldBeReported(Interval interval);
+
 }

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/HourlyF303InfoGenerator.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/HourlyF303InfoGenerator.java
@@ -42,9 +42,10 @@ final class HourlyF303InfoGenerator {
     private static final String TATL = "_TATL";
     private static final String PATL = "_PATL";
 
-    HourlyF303InfoGenerator() {
+    private HourlyF303InfoGenerator() {
         throw new AssertionError("Static class. Should not be constructed");
     }
+    public record Inputs(FbConstraintCreationContext crac, RaoResult raoResult, OffsetDateTime timestamp) {}
 
     static HourlyF303Info getInfoForNonRequestedOrFailedInterval(FlowBasedConstraintDocument flowBasedConstraintDocument, Interval interval) {
         OffsetDateTime startTime = OffsetDateTime.ofInstant(interval.getStart(), ZoneOffset.UTC);
@@ -64,11 +65,11 @@ final class HourlyF303InfoGenerator {
         return new HourlyF303Info(criticalBranches);
     }
 
-    static HourlyF303Info getInfoForSuccessfulInterval(FlowBasedConstraintDocument flowBasedConstraintDocument, Interval interval, OffsetDateTime offsetDateTime, FbConstraintCreationContext crac, RaoResult raoResult) {
-        Map<State, String> statesWithCra = getUIDOfStatesWithCra(crac, raoResult, offsetDateTime.toString());
+    static HourlyF303Info getInfoForSuccessfulInterval(FlowBasedConstraintDocument flowBasedConstraintDocument, Interval interval, Inputs inputs) {
+        Map<State, String> statesWithCra = getUIDOfStatesWithCra(inputs.crac(), inputs.raoResult(), inputs.timestamp().toString());
 
-        List<CriticalBranchType> criticalBranches = getCriticalBranchesOfSuccessfulInterval(flowBasedConstraintDocument, crac, statesWithCra, interval);
-        List<IndependantComplexVariant> complexVariants = getComplexVariantsOfSuccesfulInterval(flowBasedConstraintDocument, crac, raoResult, statesWithCra, interval);
+        List<CriticalBranchType> criticalBranches = getCriticalBranchesOfSuccessfulInterval(flowBasedConstraintDocument, inputs.crac(), statesWithCra, interval);
+        List<IndependantComplexVariant> complexVariants = getComplexVariantsOfSuccesfulInterval(flowBasedConstraintDocument, inputs.crac(), inputs.raoResult(), statesWithCra, interval);
 
         return new HourlyF303Info(criticalBranches, complexVariants);
     }

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/HourlyF303InfoGenerator.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/HourlyF303InfoGenerator.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
  * @author Philippe Edwards {@literal <philippe.edwards at rte-france.com>}
  * @author Godelaine de Montmorillon {@literal <godelaine.demontmorillon at rte-france.com>}
  */
-final class HourlyF303InfoGenerator {
+public final class HourlyF303InfoGenerator {
 
     private static final String TATL = "_TATL";
     private static final String PATL = "_PATL";
@@ -45,7 +45,8 @@ final class HourlyF303InfoGenerator {
     private HourlyF303InfoGenerator() {
         throw new AssertionError("Static class. Should not be constructed");
     }
-    public record Inputs(FbConstraintCreationContext crac, RaoResult raoResult, OffsetDateTime timestamp) {}
+
+    public record Inputs(FbConstraintCreationContext crac, RaoResult raoResult, OffsetDateTime timestamp) { }
 
     static HourlyF303Info getInfoForNonRequestedOrFailedInterval(FlowBasedConstraintDocument flowBasedConstraintDocument, Interval interval) {
         OffsetDateTime startTime = OffsetDateTime.ofInstant(interval.getStart(), ZoneOffset.UTC);

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/HourlyF303InfoGenerator.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/HourlyF303InfoGenerator.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
  * @author Baptiste Seguinot {@literal <baptiste.seguinot at rte-france.com}
  * @author Philippe Edwards {@literal <philippe.edwards at rte-france.com>}
  * @author Godelaine de Montmorillon {@literal <godelaine.demontmorillon at rte-france.com>}
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  */
 public final class HourlyF303InfoGenerator {
 

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/TaskDtoBasedDailyF303InputsProvider.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/TaskDtoBasedDailyF303InputsProvider.java
@@ -103,7 +103,7 @@ public class TaskDtoBasedDailyF303InputsProvider implements DailyF303GeneratorIn
     }
 
     private FbConstraintCreationContext getCracOfTaskDto(Network network, TaskDto taskDto, MinioAdapter minioAdapter) {
-        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
+        Optional<ProcessFileDto> processFileDto = taskDto.getInputs()
                 .stream()
                 .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
                         dto.getFileType().equals("CBCORA"))

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/TaskDtoBasedDailyF303InputsProvider.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/TaskDtoBasedDailyF303InputsProvider.java
@@ -67,6 +67,12 @@ public class TaskDtoBasedDailyF303InputsProvider implements DailyF303GeneratorIn
         }
     }
 
+    @Override
+    public boolean shouldBeReported(Interval interval) {
+        Optional<TaskDto> taskDtoOptional = getTaskDtoOfInterval(interval, tasks);
+        return taskDtoOptional.isPresent() && taskDtoOptional.get().getStatus().equals(TaskStatus.SUCCESS);
+    }
+
     private Optional<TaskDto> getTaskDtoOfInterval(Interval interval, Set<TaskDto> taskDtos) {
         return taskDtos.stream().filter(taskDto -> interval.contains(taskDto.getTimestamp().toInstant())).findFirst();
     }

--- a/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/TaskDtoBasedDailyF303InputsProvider.java
+++ b/gridcapa-core-cc-post-processing-app/src/main/java/com/farao_community/farao/core_cc_post_processing/app/services/TaskDtoBasedDailyF303InputsProvider.java
@@ -1,0 +1,137 @@
+package com.farao_community.farao.core_cc_post_processing.app.services;
+
+import com.farao_community.farao.core_cc_post_processing.app.exception.CoreCCPostProcessingInternalException;
+import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileDto;
+import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileStatus;
+import com.farao_community.farao.gridcapa.task_manager.api.TaskDto;
+import com.farao_community.farao.gridcapa.task_manager.api.TaskStatus;
+import com.farao_community.farao.minio_adapter.starter.MinioAdapter;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.openrao.data.crac.api.parameters.CracCreationParameters;
+import com.powsybl.openrao.data.crac.api.parameters.JsonCracCreationParameters;
+import com.powsybl.openrao.data.crac.io.fbconstraint.FbConstraintCreationContext;
+import com.powsybl.openrao.data.crac.io.fbconstraint.FbConstraintImporter;
+import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.FlowBasedConstraintDocument;
+import com.powsybl.openrao.data.raoresult.api.RaoResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.threeten.extra.Interval;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.farao_community.farao.core_cc_post_processing.app.util.CracUtil.importNativeCrac;
+
+public class TaskDtoBasedDailyF303InputsProvider implements DailyF303GeneratorInputsProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskDtoBasedDailyF303InputsProvider.class);
+    public static final String CRAC_CREATION_PARAMETERS_JSON = "/crac/cracCreationParameters.json";
+    private final Set<TaskDto> tasks;
+    private final MinioAdapter minioAdapter;
+
+    public TaskDtoBasedDailyF303InputsProvider(Set<TaskDto> tasks, MinioAdapter minioAdapter) {
+        this.tasks = tasks;
+        this.minioAdapter = minioAdapter;
+    }
+
+    @Override
+    public FlowBasedConstraintDocument referenceConstraintDocument() {
+        String cracFilePath = tasks.stream()
+                .findFirst().orElseThrow()
+                .getInputs()
+                .stream().filter(processFileDto -> processFileDto.getFileType().equals("CBCORA"))
+                .findFirst().orElseThrow(() -> new CoreCCPostProcessingInternalException("task dto missing cbcora file"))
+                .getFilePath();
+        return getFlowBasedConstraintDocument(cracFilePath);
+    }
+
+    @Override
+    public Optional<HourlyF303InfoGenerator.Inputs> hourlyF303InputsForInterval(Interval interval) {
+        Optional<TaskDto> taskDtoOptional = getTaskDtoOfInterval(interval, tasks);
+        if (taskDtoOptional.isPresent()) {
+            TaskDto taskDto = taskDtoOptional.get();
+            if (!taskDto.getStatus().equals(TaskStatus.SUCCESS)) {
+                return Optional.empty();
+            }
+            try {
+                Network network = getNetworkOfTaskDto(taskDto, minioAdapter);
+                FbConstraintCreationContext crac = getCracOfTaskDto(network, taskDto, minioAdapter);
+                RaoResult raoResult = getRaoResultOfTaskDto(crac, taskDto, minioAdapter);
+                return Optional.of(new HourlyF303InfoGenerator.Inputs(crac, raoResult, taskDto.getTimestamp()));
+            } catch (Exception e) {
+                return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<TaskDto> getTaskDtoOfInterval(Interval interval, Set<TaskDto> taskDtos) {
+        return taskDtos.stream().filter(taskDto -> interval.contains(taskDto.getTimestamp().toInstant())).findFirst();
+    }
+
+    private CracCreationParameters getCimCracCreationParameters() {
+        LOGGER.info("Importing Crac Creation Parameters file: {}", CRAC_CREATION_PARAMETERS_JSON);
+        return JsonCracCreationParameters.read(getClass().getResourceAsStream(CRAC_CREATION_PARAMETERS_JSON));
+    }
+
+    private FlowBasedConstraintDocument getFlowBasedConstraintDocument(String cracFilePath) {
+        FlowBasedConstraintDocument flowBasedConstraintDocument;
+        try (final InputStream cracXmlInputStream = minioAdapter.getFileFromFullPath(cracFilePath)) {
+            flowBasedConstraintDocument = importNativeCrac(cracXmlInputStream);
+        } catch (Exception e) {
+            throw new CoreCCPostProcessingInternalException("Exception occurred during F303 file creation", e);
+        }
+        return flowBasedConstraintDocument;
+    }
+
+    private Network getNetworkOfTaskDto(TaskDto taskDto, MinioAdapter minioAdapter) {
+        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
+                .stream()
+                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
+                        dto.getFileType().equals("CGM_OUT"))
+                .findAny();
+        if (processFileDto.isEmpty()) {
+            throw new RuntimeException("Missing file");
+        }
+        try (InputStream networkInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
+            return Network.read(processFileDto.get().getFilename(), networkInputStream);
+        } catch (IOException e) {
+            throw new CoreCCPostProcessingInternalException(String.format("Cannot import network of task %s", taskDto.getTimestamp()), e);
+        }
+    }
+
+    private FbConstraintCreationContext getCracOfTaskDto(Network network, TaskDto taskDto, MinioAdapter minioAdapter) {
+        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
+                .stream()
+                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
+                        dto.getFileType().equals("CBCORA"))
+                .findAny();
+        if (processFileDto.isEmpty()) {
+            throw new RuntimeException("Missing file");
+        }
+        CracCreationParameters cracCreationParameters = getCimCracCreationParameters();
+        try (InputStream cracInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
+            return (FbConstraintCreationContext) new FbConstraintImporter().importData(cracInputStream, cracCreationParameters, network, taskDto.getTimestamp());
+        } catch (IOException e) {
+            throw new CoreCCPostProcessingInternalException(String.format("Cannot import network of task %s", taskDto.getTimestamp()), e);
+        }
+    }
+
+    private RaoResult getRaoResultOfTaskDto(FbConstraintCreationContext crac, TaskDto taskDto, MinioAdapter minioAdapter) {
+        Optional<ProcessFileDto> processFileDto = taskDto.getOutputs()
+                .stream()
+                .filter(dto -> dto.getProcessFileStatus().equals(ProcessFileStatus.VALIDATED) &&
+                        dto.getFileType().equals("RAO_RESULT"))
+                .findAny();
+        if (processFileDto.isEmpty()) {
+            throw new RuntimeException("Missing file");
+        }
+        try (InputStream raoResultInputStream = minioAdapter.getFileFromFullPath(processFileDto.get().getFilePath())) {
+            return RaoResult.read(raoResultInputStream, crac.getCrac());
+        } catch (IOException e) {
+            throw new CoreCCPostProcessingInternalException(String.format("Cannot import RAO result of hourly RAO response of instant %s", taskDto.getTimestamp()), e);
+        }
+    }
+}

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/Utils.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/Utils.java
@@ -67,6 +67,10 @@ public class Utils {
     public static final MinioFileWriter MINIO_FILE_WRITER = new MinioFileWriter(PROPERTIES, MINIO_CLIENT);
     public static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
 
+    public static TaskDto successTaskWithInputsAndOutputs(List<ProcessFileDto> inputs, List<ProcessFileDto> outputs) {
+        return new TaskDto(UUID.fromString("4fb56583-bcec-4ed9-9839-0984b7324989"), OffsetDateTime.parse("2023-08-21T15:16:45Z"), TaskStatus.SUCCESS, inputs, inputs, outputs, PROCESS_EVENTS, PROCESS_RUN_DTOS_ONE, List.of());
+    }
+
     public static void neutralizeCreationDate(File file, boolean isXml) throws IOException {
         BufferedReader reader = new BufferedReader(new FileReader(file));
         String regex = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}Z";

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator1Test.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator1Test.java
@@ -23,10 +23,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.io.InputStream;
 import java.time.OffsetDateTime;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator1Test.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator1Test.java
@@ -16,10 +16,8 @@ import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.FlowBasedConstraintDocu
 import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.IndependantComplexVariant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -43,14 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 class DailyF303Generator1Test {
-
-    /*
-     * test-case initially designed to test the F303 export, with two hours of data, one contingency
-     * and some elements which are not CNEC and not MNEC
-     */
-
-    @Autowired
-    private DailyF303Generator dailyF303Generator;
 
     @MockBean
     private MinioAdapter minioAdapter;
@@ -110,7 +100,8 @@ class DailyF303Generator1Test {
     @Test
     void validateMergedFlowBasedCreation() {
         assertEquals(24, taskDtos.size());
-        FlowBasedConstraintDocument dailyFbConstDocument = dailyF303Generator.generate(taskDtos);
+        var inputs = new TaskDtoBasedDailyF303InputsProvider(taskDtos, minioAdapter);
+        FlowBasedConstraintDocument dailyFbConstDocument = DailyF303Generator.generate(inputs);
         assertDocumentProperties(dailyFbConstDocument);
         assertCriticalBranches(dailyFbConstDocument.getCriticalBranches().getCriticalBranch());
         assertComplexVariants(dailyFbConstDocument.getComplexVariants().getComplexVariant());

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator1Test.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator1Test.java
@@ -45,8 +45,6 @@ class DailyF303Generator1Test {
     @MockBean
     private MinioAdapter minioAdapter;
     private final Set<TaskDto> taskDtos = new HashSet<>();
-    private final Map<TaskDto, ProcessFileDto> raoResult = new HashMap<>();
-    private final Map<TaskDto, ProcessFileDto> cgms = new HashMap<>();
 
     @BeforeEach
     public void setUp() {
@@ -83,11 +81,6 @@ class DailyF303Generator1Test {
         ProcessFileDto raoResult2ProcessFile = new ProcessFileDto("/CORE/CC/raoResult2.json", "RAO_RESULT", ProcessFileStatus.VALIDATED, "raoResult2.json", "docId", timestamp1330);
         final TaskDto successTaskTwo = new TaskDto(UUID.fromString(baseUuid + 14), timestamp1330, TaskStatus.SUCCESS, List.of(cracProcessFile), List.of(cracProcessFile), List.of(cgm2ProcessFile, raoResult2ProcessFile), List.of(), List.of(), List.of());
         taskDtos.add(successTaskTwo);
-
-        raoResult.put(successTaskOne, raoResult1ProcessFile);
-        raoResult.put(successTaskTwo, raoResult2ProcessFile);
-        cgms.put(successTaskOne, cgm1ProcessFile);
-        cgms.put(successTaskTwo, cgm2ProcessFile);
 
         // NOT_CREATED tasks from 2019-01-08 14:00 to 2019-01-08 23:00
         for (int h = 15; h <= 23; h++) {

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator1Test.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator1Test.java
@@ -16,7 +16,9 @@ import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.FlowBasedConstraintDocu
 import com.powsybl.openrao.data.crac.io.fbconstraint.xsd.IndependantComplexVariant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -58,20 +60,11 @@ class DailyF303Generator1Test {
 
     @BeforeEach
     public void setUp() {
-        InputStream inputCracXmlInputStream = getClass().getResourceAsStream("/services/f303-1/inputs/F301.xml");
-        Mockito.doReturn(inputCracXmlInputStream).when(minioAdapter).getFileFromFullPath("/CORE/CC/inputCracXml.xml");
-
-        InputStream network1InputStream = getClass().getResourceAsStream("/services/f303-1/inputs/networks/20190108_1230.xiidm");
-        Mockito.doReturn(network1InputStream).when(minioAdapter).getFileFromFullPath("/CORE/CC/network1.xiidm");
-
-        InputStream raoResult1InputStream = getClass().getResourceAsStream("/services/f303-1/hourly_rao_results/20190108_1230/raoResult.json");
-        Mockito.doReturn(raoResult1InputStream).when(minioAdapter).getFileFromFullPath("/CORE/CC/raoResult1.json");
-
-        InputStream network2InputStream = getClass().getResourceAsStream("/services/f303-1/inputs/networks/20190108_1330.xiidm");
-        Mockito.doReturn(network2InputStream).when(minioAdapter).getFileFromFullPath("/CORE/CC/network2.xiidm");
-
-        InputStream raoResult2InputStream = getClass().getResourceAsStream("/services/f303-1/hourly_rao_results/20190108_1330/raoResult.json");
-        Mockito.doReturn(raoResult2InputStream).when(minioAdapter).getFileFromFullPath("/CORE/CC/raoResult2.json");
+        Mockito.doAnswer((Answer<InputStream>) invocation -> getClass().getResourceAsStream("/services/f303-1/inputs/F301.xml")).when(minioAdapter).getFileFromFullPath("/CORE/CC/inputCracXml.xml");
+        Mockito.doAnswer((Answer<InputStream>) invocation -> getClass().getResourceAsStream("/services/f303-1/inputs/networks/20190108_1230.xiidm")).when(minioAdapter).getFileFromFullPath("/CORE/CC/network1.xiidm");
+        Mockito.doAnswer((Answer<InputStream>) invocation -> getClass().getResourceAsStream("/services/f303-1/hourly_rao_results/20190108_1230/raoResult.json")).when(minioAdapter).getFileFromFullPath("/CORE/CC/raoResult1.json");
+        Mockito.doAnswer((Answer<InputStream>) invocation -> getClass().getResourceAsStream("/services/f303-1/inputs/networks/20190108_1330.xiidm")).when(minioAdapter).getFileFromFullPath("/CORE/CC/network2.xiidm");
+        Mockito.doAnswer((Answer<InputStream>) invocation -> getClass().getResourceAsStream("/services/f303-1/hourly_rao_results/20190108_1330/raoResult.json")).when(minioAdapter).getFileFromFullPath("/CORE/CC/raoResult2.json");
 
         String timeStampBegin = "2019-01-07T23:00Z";
 
@@ -84,21 +77,21 @@ class DailyF303Generator1Test {
         for (int h = 0; h <= 12; h++) {
             // Set tasks' status to NOT_CREATED to ignore them
             OffsetDateTime timestamp = firstTimestamp.plusHours(h);
-            taskDtos.add(new TaskDto(UUID.fromString(baseUuid + h), timestamp, TaskStatus.NOT_CREATED, List.of(cracProcessFile), List.of(), List.of(), List.of(), List.of(), List.of()));
+            taskDtos.add(new TaskDto(UUID.fromString(baseUuid + h), timestamp, TaskStatus.NOT_CREATED, List.of(cracProcessFile), List.of(cracProcessFile), List.of(), List.of(), List.of(), List.of()));
         }
 
         // SUCCESS task at 12:30
         OffsetDateTime timestamp1230 = OffsetDateTime.parse("2019-01-08T12:30:00Z");
         ProcessFileDto cgm1ProcessFile = new ProcessFileDto("/CORE/CC/network1.xiidm", "CGM_OUT", ProcessFileStatus.VALIDATED, "network1.xiidm", "docId", timestamp1230);
         ProcessFileDto raoResult1ProcessFile = new ProcessFileDto("/CORE/CC/raoResult1.json", "RAO_RESULT", ProcessFileStatus.VALIDATED, "raoResult1.json", "docId", timestamp1230);
-        final TaskDto successTaskOne = new TaskDto(UUID.fromString(baseUuid + 13), timestamp1230, TaskStatus.SUCCESS, List.of(cracProcessFile), List.of(cgm1ProcessFile, raoResult1ProcessFile), List.of(), List.of(), List.of(), List.of());
+        final TaskDto successTaskOne = new TaskDto(UUID.fromString(baseUuid + 13), timestamp1230, TaskStatus.SUCCESS, List.of(cracProcessFile), List.of(cracProcessFile), List.of(cgm1ProcessFile, raoResult1ProcessFile), List.of(), List.of(), List.of());
         taskDtos.add(successTaskOne);
 
         // SUCCESS task at 13:30
         OffsetDateTime timestamp1330 = OffsetDateTime.parse("2019-01-08T13:30:00Z");
         ProcessFileDto cgm2ProcessFile = new ProcessFileDto("/CORE/CC/network2.xiidm", "CGM_OUT", ProcessFileStatus.VALIDATED, "network2.xiidm", "docId", timestamp1330);
         ProcessFileDto raoResult2ProcessFile = new ProcessFileDto("/CORE/CC/raoResult2.json", "RAO_RESULT", ProcessFileStatus.VALIDATED, "raoResult2.json", "docId", timestamp1330);
-        final TaskDto successTaskTwo = new TaskDto(UUID.fromString(baseUuid + 14), timestamp1330, TaskStatus.SUCCESS, List.of(cracProcessFile), List.of(cgm2ProcessFile, raoResult2ProcessFile), List.of(), List.of(), List.of(), List.of());
+        final TaskDto successTaskTwo = new TaskDto(UUID.fromString(baseUuid + 14), timestamp1330, TaskStatus.SUCCESS, List.of(cracProcessFile), List.of(cracProcessFile), List.of(cgm2ProcessFile, raoResult2ProcessFile), List.of(), List.of(), List.of());
         taskDtos.add(successTaskTwo);
 
         raoResult.put(successTaskOne, raoResult1ProcessFile);
@@ -110,14 +103,14 @@ class DailyF303Generator1Test {
         for (int h = 15; h <= 23; h++) {
             // Set tasks' status to NOT_CREATED to ignore them
             OffsetDateTime timestamp = firstTimestamp.plusHours(h);
-            taskDtos.add(new TaskDto(UUID.fromString(baseUuid + h), timestamp, TaskStatus.NOT_CREATED, List.of(cracProcessFile), List.of(), List.of(), List.of(), List.of(), List.of()));
+            taskDtos.add(new TaskDto(UUID.fromString(baseUuid + h), timestamp, TaskStatus.NOT_CREATED, List.of(cracProcessFile), List.of(cracProcessFile), List.of(), List.of(), List.of(), List.of()));
         }
     }
 
     @Test
     void validateMergedFlowBasedCreation() {
         assertEquals(24, taskDtos.size());
-        FlowBasedConstraintDocument dailyFbConstDocument = dailyF303Generator.generate(raoResult, cgms);
+        FlowBasedConstraintDocument dailyFbConstDocument = dailyF303Generator.generate(taskDtos);
         assertDocumentProperties(dailyFbConstDocument);
         assertCriticalBranches(dailyFbConstDocument.getCriticalBranches().getCriticalBranch());
         assertComplexVariants(dailyFbConstDocument.getComplexVariants().getComplexVariant());

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator2Test.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator2Test.java
@@ -29,10 +29,8 @@ import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -59,8 +57,6 @@ class DailyF303Generator2Test {
     @MockBean
     private MinioAdapter minioAdapter;
     private final Set<TaskDto> taskDtos = new HashSet<>();
-    private final Map<TaskDto, ProcessFileDto> raoResult = new HashMap<>();
-    private final Map<TaskDto, ProcessFileDto> cgms = new HashMap<>();
 
     @BeforeEach
     public void setUp() {
@@ -132,8 +128,6 @@ class DailyF303Generator2Test {
             // add task
             final TaskDto taskDto = new TaskDto(UUID.fromString(baseUuid + h), timestamp, TaskStatus.SUCCESS, List.of(cracProcessFile), List.of(cracProcessFile), List.of(cgmProcessFile, raoResultProcessFile), List.of(), List.of(), List.of());
             taskDtos.add(taskDto);
-            raoResult.put(taskDto, raoResultProcessFile);
-            cgms.put(taskDto, cgmProcessFile);
         }
 
         // add failed task between 15:00 and 16:00

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator2Test.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/DailyF303Generator2Test.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -57,9 +56,6 @@ class DailyF303Generator2Test {
      * critical branches with varying parameters other time in the F301, and some invalid
      * elements in the F301 which are not imported
      */
-
-    @Autowired
-    private DailyF303Generator dailyFbConstraintDocumentGenerator;
     @MockBean
     private MinioAdapter minioAdapter;
     private final Set<TaskDto> taskDtos = new HashSet<>();
@@ -153,7 +149,8 @@ class DailyF303Generator2Test {
     @Test
     void testF303Generation() {
         assertEquals(24, taskDtos.size());
-        FlowBasedConstraintDocument dailyFbConstDocument = dailyFbConstraintDocumentGenerator.generate(taskDtos);
+        var inputs = new TaskDtoBasedDailyF303InputsProvider(taskDtos, minioAdapter);
+        FlowBasedConstraintDocument dailyFbConstDocument = DailyF303Generator.generate(inputs);
 
         checkHeaders(dailyFbConstDocument);
 

--- a/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/HourlyF303InfoGeneratorTest.java
+++ b/gridcapa-core-cc-post-processing-app/src/test/java/com/farao_community/farao/core_cc_post_processing/app/services/HourlyF303InfoGeneratorTest.java
@@ -67,7 +67,8 @@ class HourlyF303InfoGeneratorTest {
         Network network = networkFromResources("/services/network.uct");
         FbConstraintCreationContext crac = cracFromResources(network, timestamp, "/services/crac.xml");
         RaoResult raoResult = taoResultFromResource(crac, "/services/raoResult.json");
-        HourlyF303Info hourlyF303Info = HourlyF303InfoGenerator.getInfoForSuccessfulInterval(nativeCrac, interval, timestamp, crac, raoResult);
+        HourlyF303InfoGenerator.Inputs inputs = new HourlyF303InfoGenerator.Inputs(crac, raoResult, timestamp);
+        HourlyF303Info hourlyF303Info = HourlyF303InfoGenerator.getInfoForSuccessfulInterval(nativeCrac, interval, inputs);
         checkCriticalBranchesWithTatlPatl(hourlyF303Info);
         checkComplexVariants(hourlyF303Info);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
Current implementation of the Daily F303 file generation is not reusable outside GridCapa, because intricated with MinIO data sources and TaskDtos.


**What is the new behavior (if this is a feature change)?**
The algorithm is made agnostic of the technical infrastructure of GridCapa to allow to use it with different data sources


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No

